### PR TITLE
Add seconds per correct case metric and model type filter

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -307,6 +307,7 @@ main {
 }
 
 .leaderboard.detailed-view .pass-rate-first,
+.leaderboard.detailed-view .seconds-per-correct,
 .leaderboard.detailed-view .date,
 .leaderboard.detailed-view .error-outputs,
 .leaderboard.detailed-view .timeouts,
@@ -328,6 +329,11 @@ main {
 @media (max-width: 768px) {
   .controls-container {
     flex-direction: column;
+  }
+  
+  .language-dropdown-container {
+    flex-direction: column;
+    gap: 10px;
   }
 
   .view-toggle-container {
@@ -364,6 +370,8 @@ main {
 .language-dropdown-container {
   display: flex;
   justify-content: center;
+  align-items: center;
+  gap: 20px;
   margin-bottom: 15px;
 }
 
@@ -422,6 +430,64 @@ main {
   display: block;
 }
 
+/* Model Type Dropdown Styles */
+.model-type-dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.model-type-dropdown-button {
+  background-color: var(--background-light);
+  color: var(--text);
+  border: 1px solid var(--primary-dark);
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  font-size: 0.8rem;
+  width: 100%;
+  min-width: 120px;
+}
+
+.model-type-dropdown-content {
+  display: none;
+  position: absolute;
+  background-color: var(--background);
+  min-width: 120px;
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.5);
+  z-index: 1;
+  border: 1px solid var(--primary-dark);
+  border-radius: 4px;
+  left: 0;
+  right: 0;
+}
+
+.model-type-dropdown-content button {
+  color: var(--text);
+  padding: 8px 12px;
+  text-decoration: none;
+  display: block;
+  text-align: left;
+  border: none;
+  background: transparent;
+  width: 100%;
+  border-radius: 0;
+  font-size: 0.8rem;
+}
+
+.model-type-dropdown-content button:hover {
+  background-color: rgba(0, 255, 0, 0.1);
+}
+
+.model-type-dropdown-content button.active {
+  background-color: var(--primary-dark);
+  color: var(--background);
+}
+
+.model-type-dropdown:hover .model-type-dropdown-content {
+  display: block;
+}
+
 button {
   background-color: var(--background-light);
   color: var(--text);
@@ -436,6 +502,7 @@ button:hover, button.active {
   background-color: var(--primary-dark);
   color: var(--background);
 }
+
 
 .leaderboard-container {
   overflow-x: auto;
@@ -1351,7 +1418,8 @@ footer p {
   .leaderboard.detailed-view .date,
   .leaderboard.detailed-view .error-outputs,
   .leaderboard.detailed-view .timeouts,
-  .leaderboard.detailed-view .malformed {
+  .leaderboard.detailed-view .malformed,
+  .leaderboard.detailed-view .seconds-per-correct {
     display: none;
   }
 }

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -68,7 +68,7 @@ export default function Leaderboard({ models }: LeaderboardProps) {
     if (modelTypeFilter === 'opensource') {
       filteredModels = models.filter(model => model.details.isOpenSource === true);
     } else if (modelTypeFilter === 'proprietary') {
-      filteredModels = models.filter(model => model.details.isOpenSource === false || model.details.isOpenSource === undefined);
+      filteredModels = models.filter(model => model.details.isOpenSource === false);
     }
     
     return [...filteredModels].sort((a, b) => {
@@ -312,7 +312,7 @@ export default function Leaderboard({ models }: LeaderboardProps) {
               </th>
               <th
                 className={`speed sortable ${sortColumn === 'speed' ? 'active' : ''}`}
-                onClick={() => sortBy('speed', selectedLanguage)}
+                onClick={() => sortBy('speed')}
               >
                 <span className="tooltip-container">
                   Speed per Case
@@ -323,7 +323,7 @@ export default function Leaderboard({ models }: LeaderboardProps) {
               </th>
               <th
                 className={`cost sortable ${sortColumn === 'cost' ? 'active' : ''}`}
-                onClick={() => sortBy('cost', selectedLanguage)}
+                onClick={() => sortBy('cost')}
               >
                 Cost
                 {sortColumn === 'cost' && (

--- a/src/components/ModelDetailModal.tsx
+++ b/src/components/ModelDetailModal.tsx
@@ -128,6 +128,14 @@ export default function ModelDetailModal({ model, onClose }: ModelDetailModalPro
               <span className="detail-label">Speed:</span>
               <span className="detail-value">{model.details.seconds_per_case} seconds per case</span>
             </div>
+            {model.details.pass_num_2 > 0 && (
+              <div className="detail-item">
+                <span className="detail-label">Seconds per Correct Case:</span>
+                <span className="detail-value">
+                  {((model.details.seconds_per_case * model.details.total_tests) / model.details.pass_num_2).toFixed(1)} seconds
+                </span>
+              </div>
+            )}
             <div className="detail-item">
               <span className="detail-label">Total Cost:</span>
               <span className="detail-value">${model.details.total_cost}</span>


### PR DESCRIPTION
I was curious to see how the models would rank by a metric of how many seconds of work per correct answer in the benchmark. I thought I might as well make it a PR in case you want to add it and made a few fairly unoffensive changes - I put it all in the detailed view, no changes to the landing apart from the open source / proprietary filter

- Add 'Seconds per Correct Case' sortable column in detailed view
- Fix bug where language filter reset when sorting by cost/speed
- Add model type filter dropdown (All/Open Source/Proprietary)
- Show seconds per correct case in model detail modal
- Update CSS for new dropdown styling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Seconds per Correct Case" column to the leaderboard, allowing sorting and display of this new performance metric.
  * Introduced a dropdown filter to view all models, only open source models, or only proprietary models on the leaderboard.
  * The model detail modal now displays "Seconds per Correct Case" when applicable.

* **Style**
  * Updated styles for the new model type dropdown and improved alignment and spacing for dropdown containers.
  * Enhanced responsive design for dropdown containers on smaller screens.

* **Bug Fixes**
  * Sorting and filtering logic updated to support new features and maintain consistency across columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->